### PR TITLE
Make Windows / Linux specifics stand out

### DIFF
--- a/build-config-testrun-jenkins.md
+++ b/build-config-testrun-jenkins.md
@@ -8,7 +8,7 @@ Then, for each test category (Unit Test, Performance Test, Browser Test or Web A
 
 Test Run's id is available as environment variable which can be passed to the Dynatrace AppMon agent in the build script.
 
-**Example:**
+**Example (Linux 64-bit):**
 ```xml
 <jvmarg value="-agentpath:$/var/lib/dynatrace/agent/lib64/libdtagent.so=name=JavaAgent,
 server=localhost:9998,loglevel=warning,optionTestRunIdJava=${dtTestrunID}" />
@@ -18,6 +18,12 @@ server=localhost:9998,loglevel=warning,optionTestRunIdJava=${dtTestrunID}" />
 
 You can pass java arguments into surefire and failsafe plugins directly from commandline, without any changes in your Maven build script needed.
 Just adapt and add following arguments in `Build -> Invoke top-level Maven targets -> Goals`:
+
+Windows:
 ```batch
--DargLine="-agentpath:<path to dtagent.dll/dtagent.so>=name=<agent name>,server=<host[:port]>,optionTestRunIdJava=%dtTestrunID%"
+-DargLine="-agentpath:<path to dtagent.dll>=name=<agent name>,server=<host[:port]>,optionTestRunIdJava=%dtTestrunID%"
+```
+Linux
+```batch
+-DargLine="-agentpath:<path to dtagent.so>=name=<agent name>,server=<host[:port]>,optionTestRunIdJava=${dtTestrunID}"
 ```

--- a/build-config-testrun-jenkins.md
+++ b/build-config-testrun-jenkins.md
@@ -23,7 +23,7 @@ Windows:
 ```batch
 -DargLine="-agentpath:<path to dtagent.dll>=name=<agent name>,server=<host[:port]>,optionTestRunIdJava=%dtTestrunID%"
 ```
-Linux
+Linux:
 ```batch
 -DargLine="-agentpath:<path to dtagent.so>=name=<agent name>,server=<host[:port]>,optionTestRunIdJava=${dtTestrunID}"
 ```


### PR DESCRIPTION
Make Windows / Linux specifics stand out

I would like to make sure that there are obvious differences between Windows and Linux installations.

I ran myself into a problem because I blindly copied and pasted the argLine and only edited the <path to dtagent.xxx> part but forgot to edit the variable replacement part.

I also added two comments to suspicious looking things - please review them.

Best regards
Josef Lehner